### PR TITLE
Fix Travis builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 language: python
 python:
 - '2.7'
-install:
-- sudo add-apt-repository -y ppa:texlive-backports/ppa
-- sudo apt-get update
-- sudo apt-get install texlive make
+sudo: true
+dist: trusty
+before_install:
+- sudo apt-get install texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-generic-recommended purifyeps
 script:
 - (cd sheets; LATEX_OPTS="-interaction=nonstopmode -shell-escape" make pdfrelease)
 deploy:
-  provider: s3
-  access_key_id: AKIAJNGHJWMQEU6QAIPQ
-  secret_access_key:
-    secure: tviNwD7V1A4WRzCwnRGXTHUf6kdbEG+7X7AxnTnSEf+ar1iXl/1aplLKFccc9vwzlGy0sUVqv0wg0kmQkIMhUhdZovOD4gUnOARUZzkTHj9L0apIb2gxLyEyYHCRFiIKLT6Vto8iPbU3ALCoQAhk2oQwM+dznQb6lg+U5HpRK8U=
-  bucket: livewires-worksheets
-  local-dir: release
-  upload-dir: "$TRAVIS_BUILD_NUMBER"
-  acl: !ruby/string:HighLine::String public_read
+  provider: releases
+  api_key:
+    secure: cONhoGDyJTI1AB3N52EXNKoP6VivURket/NZEIzEpLgg2iiXzvevTZehOIJmdB67fdW0cHqkgpsD2kxxJ/BkoJN7atOPdmnIOeKD2GX8ntT33Fcvs3Co2drVPLtpriWQhnY7qNVBsYpm4kuyRZ+gAjFkQus6JC3+YF+O3U29lGTR/CFBmZMgIR+LLUVZMOYlugAOe/6aIYAKhw7jG2B4Do1s/gPM/l9fexqYr5B+4iiTRDZgDo9PcwhyzTEU7XsHhEHf3JQWxWE5U1XybBvvb826EIEj3ak/TaTvF5xe2uIuTGU9Hx5GAvJEOjuB3s/WAhVTGLm50y58ipmLiTg54Ya6tkdLZzsArX+wAexjW58kAlGDiFIvQcmvcdbLBfgtnlAR7MsZEksaJ5TWVZohGMAK0+umIlmJ7sqnQu2g5x11BxAM2TEW5TyTTtlQL1u4Tbc11UGCkVdzqPTBrEJis0b7WTrWawpDlqi22GXeHPl2jI372TMXT5crdIZAgC1zJdF7B+cpxE2bJLrm4JUnAqKtZWs/nmwKMDZ0Z5kG9AtL9aFQhgCr3C7SG+f6HBTiylYRZtucrXWzjU7r8vU9Bc64efvcQr/KFFo9xjLxDRpEyG0t/0q3LUKQdrDpNdVmMXJqYL/cWLHqEoev+LngeIuRhpvX9eeqXdaR0p+E688=
+  file: release/livewires-pdfs.tar.gz
   skip_cleanup: true
   on:
     repo: livewires/python
+    tags: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ deploy:
   provider: releases
   api_key:
     secure: cONhoGDyJTI1AB3N52EXNKoP6VivURket/NZEIzEpLgg2iiXzvevTZehOIJmdB67fdW0cHqkgpsD2kxxJ/BkoJN7atOPdmnIOeKD2GX8ntT33Fcvs3Co2drVPLtpriWQhnY7qNVBsYpm4kuyRZ+gAjFkQus6JC3+YF+O3U29lGTR/CFBmZMgIR+LLUVZMOYlugAOe/6aIYAKhw7jG2B4Do1s/gPM/l9fexqYr5B+4iiTRDZgDo9PcwhyzTEU7XsHhEHf3JQWxWE5U1XybBvvb826EIEj3ak/TaTvF5xe2uIuTGU9Hx5GAvJEOjuB3s/WAhVTGLm50y58ipmLiTg54Ya6tkdLZzsArX+wAexjW58kAlGDiFIvQcmvcdbLBfgtnlAR7MsZEksaJ5TWVZohGMAK0+umIlmJ7sqnQu2g5x11BxAM2TEW5TyTTtlQL1u4Tbc11UGCkVdzqPTBrEJis0b7WTrWawpDlqi22GXeHPl2jI372TMXT5crdIZAgC1zJdF7B+cpxE2bJLrm4JUnAqKtZWs/nmwKMDZ0Z5kG9AtL9aFQhgCr3C7SG+f6HBTiylYRZtucrXWzjU7r8vU9Bc64efvcQr/KFFo9xjLxDRpEyG0t/0q3LUKQdrDpNdVmMXJqYL/cWLHqEoev+LngeIuRhpvX9eeqXdaR0p+E688=
-  file: release/livewires-pdfs.tar.gz
+  file: release/livewires-pdfs.zip
   skip_cleanup: true
   on:
     repo: livewires/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 before_install:
 - sudo apt-get install texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-generic-recommended purifyeps
 script:
-- (cd sheets; LATEX_OPTS="-interaction=nonstopmode -shell-escape" make pdfrelease)
+- (cd sheets; LATEX_OPTS="-interaction=nonstopmode" make pdfrelease)
 deploy:
   provider: releases
   api_key:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You can find the package on the [downloads page](https://github.com/livewires/py
 
 ## Getting the sheets ##
 
-The worksheets are built by Travis CI, and a tarballs are output to the livewires-worksheet S3 bucket; a nice viewer for the contents is available [here](http://shrub.appspot.com/livewires-worksheets/?s=date:d).
+The worksheets are built by Travis CI, and zip files are saved to GitHub; you
+can download them from the [Releases page](https://github.com/tjvr/livewires/releases/latest).
 
 ## About the course ##
 

--- a/sheets/Makefile
+++ b/sheets/Makefile
@@ -10,7 +10,7 @@
 .dvi.ps:
 	dvips -o $@ $<
 .ltx.pdf:
-	pdflatex $(LATEX_OPTS) $< $@; pdflatex $(LATEX_OPTS) $< $@
+	pdflatex $(LATEX_OPTS) -shell-escape $< $@; pdflatex $(LATEX_OPTS) -shell-escape $< $@
 
 # If you add LaTeX source files, you'll need to change both SOURCES and
 # TARGETS. Don't include things in the games directory in SOURCES or

--- a/sheets/Makefile
+++ b/sheets/Makefile
@@ -1,6 +1,6 @@
 # Makefile for LW worksheets
 # $Id: Makefile,v 1.12 2001/10/28 21:41:51 paul Exp paul $
-# pdrelease is probably the target you want to produce a tar.gz file
+# pdrelease is probably the target you want to produce a zip file
 # all target is all the worksheets in PDF format
 
 .SUFFIXES: .ltx .dvi .ps .pdf
@@ -87,16 +87,14 @@ COPYING.txt: COPYING.txt.src $(SOURCES) mkcopying.py
 ../release:
 	mkdir ../release
 
-../release/livewires-pdfs.tar.gz: all README.md COPYING.txt CHANGES.txt ../release
-	tar --dereference -cvf ../release/livewires-pdfs.tar ./*.pdf games/*.pdf \
-	$(PDFAUX)
-	gzip --force --best ../release/livewires-pdfs.tar
+../release/livewires-pdfs.zip: all README.md COPYING.txt CHANGES.txt ../release
+	zip ../release/livewires-pdfs.zip ./*.pdf games/*.pdf $(PDFAUX)
 
 ../release/livewires-ltx.tar.gz: $(SOURCES) $(AUX) ../release
 	tar --dereference -cvf ../release/livewires-ltx.tar $(SOURCES) $(AUX)
 	gzip --force --best ../release/livewires-ltx.tar
 
-pdfrelease: ../release/livewires-pdfs.tar.gz
+pdfrelease: ../release/livewires-pdfs.zip
 
 srcrelease: ../release/livewires-ltx.tar.gz
 

--- a/sheets/README-latex.md
+++ b/sheets/README-latex.md
@@ -41,6 +41,8 @@ What you will need to use the source:
   ask us how to get LaTeX working, as we're not experts. Pre-packaged
   versions of LaTeX are available for most operating systems.
 
+    [On OS X, you can try `brew install mactex`.]
+
 - Your life will be easier if you have a working Unix "make" utility (we
   use GNU Make). If you're using Windows, try the Cygnus utilities.
 
@@ -114,7 +116,7 @@ the output of the script and the standard licence file.
 pdfrelease:
 -----------
 
-The pdfrelease target produces a release .tar.gz file of the PDFs in the
+The pdfrelease target produces a release .zip file of the PDFs in the
 release, along with the README.txt and COPYING.txt files.
 
 srcrelease:

--- a/sheets/games/Makefile
+++ b/sheets/games/Makefile
@@ -8,7 +8,7 @@
 .dvi.ps:
 	dvips -o $@ $<
 .ltx.pdf:
-	pdflatex $(LATEX_OPTS) $<; pdflatex $(LATEX_OPTS) $<
+	pdflatex $(LATEX_OPTS) -shell-escape $<; pdflatex $(LATEX_OPTS) -shell-escape $<
 
 # Note: if you add to these and want your LaTeX source to go in the
 # source release archive, you'll need to add the filenames of the latex


### PR DESCRIPTION
For #8.

This fixes the Travis builds, which seem like a nice way to have worksheet zip files prepared automatically for every release. (Travis's infrastructure changed, and we had to upgrade to match.)

I've switched to generating .zip files instead of tarballs, since .tar.gz files are a pain on Windows.

This also adds -shell-escape to the Makefile, since modern TeX distributions seem to require that.
